### PR TITLE
Update element selector query

### DIFF
--- a/src/kill-sticky.js
+++ b/src/kill-sticky.js
@@ -1,12 +1,12 @@
 (function () {
 
-    document.querySelectorAll('body *').forEach(function(node) {
+    document.querySelectorAll('body > *').forEach(function(node) {
         if (['fixed', 'sticky'].includes(getComputedStyle(node).position))  {
             node.parentNode.removeChild(node);
         }
     });
 
-    document.querySelectorAll('html *').forEach(function(node) {
+    document.querySelectorAll('body > *').forEach(function(node) {
         var s = getComputedStyle(node);
         if ('hidden' === s['overflow']) { node.style['overflow'] = 'visible'; }
         if ('hidden' === s['overflow-x']) { node.style['overflow-x'] = 'visible'; }


### PR DESCRIPTION
Selecting only direct descendants of body seems to work better for me. The previous selector seems more prone to ruin other UI elements on the page