### PR TITLE
Fix build by converting bookmarkletify.js to an ES module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM node:current-alpine
 
-WORKDIR /kill-sticky
+WORKDIR /build/kill-sticky
 
 RUN set -x \
-        && npm install uglify-js get-stdin mustache -g
+	&& mkdir /build/node_modules \
+        && npm install -g uglify-js mustache \
+        && npm install get-stdin
 
 ENTRYPOINT uglifyjs <src/kill-sticky.js \
-        | NODE_PATH=$(npm root --quiet -g) node src/bookmarkletify.js \
+        | node src/bookmarkletify.mjs \
         | mustache - src/README.mustache.md > README.md

--- a/Makefile
+++ b/Makefile
@@ -2,5 +2,5 @@
 
 all:
 	docker build . -t kill-sticky
-	docker run --rm -t -v $(shell pwd):/kill-sticky kill-sticky
+	docker run --rm -t -v $(shell pwd):/build/kill-sticky kill-sticky
 	docker rmi kill-sticky

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ We're creating a bookmarklet, so our code needs to be minified and URL encoded.
 Run the following the project root directory:
 
 ```console
-$ docker build . -t kill-sticky && docker run --rm -it -v $(pwd):/kill-sticky kill-sticky
+$ docker build . -t kill-sticky && docker run --rm -it -v $(pwd):/build/kill-sticky kill-sticky
 ```
 
 _This will update the project README.md with the build version._

--- a/src/README.mustache.md
+++ b/src/README.mustache.md
@@ -72,7 +72,7 @@ We're creating a bookmarklet, so our code needs to be minified and URL encoded.
 Run the following the project root directory:
 
 ```console
-$ docker build . -t kill-sticky && docker run --rm -it -v $(pwd):/kill-sticky kill-sticky
+$ docker build . -t kill-sticky && docker run --rm -it -v $(pwd):/build/kill-sticky kill-sticky
 ```
 
 _This will update the project README.md with the build version._

--- a/src/bookmarkletify.mjs
+++ b/src/bookmarkletify.mjs
@@ -1,4 +1,4 @@
-const getStdin = require('get-stdin');
+import getStdin from 'get-stdin';
 
 getStdin().then(str => {
     console.log(`{"bookmarklet": "javascript:${encodeURIComponent(str)}"}`);


### PR DESCRIPTION
The package 'get-stdin' switched to an ES module in version 9.0.0 \[1], which broke the build (full error message below).

The error could be fixed by switching to a dynamic import(), namely `import('get-stdin').then(...)`, but that's awkward; so instead this commit converts bookmarkletify.js to an ES module (by changing the file extension to .mjs), which allows using the nicer import statement syntax: `import getStdin from 'get-stdin';`.

There is an additional problem: import specifiers don't support the NODE_PATH environment variable\[2] and only search local 'node_modules' directories, so the 'get-stdin' module is not found.

This commit fixes the module search problem by installing the 'get-stdin' package locally instead of globally. (The other packages are still installed globally, so that their executables will be available in the default $PATH.)

The final complication is the location of the 'node_modules' directory. The build command bind-mounts the repository into the container on /kill-sticky. Creating a 'node_modules' directory inside /kill-sticky at build time wouldn't work, because the bind mount would hide it. And creating it at runtime is ugly, because it pollutes the directory outside the container.

Instead, this commit moves /kill-sticky to /build/kill-sticky, and then creates the 'node_modules' directory in /build (outside the 'kill-sticky' directory so it won't pollute the repository, but still in the module search path).

---

Here is the error message with get-stdin 9.0.0 prior to this commit:

```
/kill-sticky/src/bookmarkletify.js:1
const getStdin = require('get-stdin');
                 ^

Error [ERR_REQUIRE_ESM]: require() of ES Module /usr/local/lib/node_modules/get-stdin/index.js from /kill-sticky/src/bookmarkletify.js not supported.
Instead change the require of index.js in /kill-sticky/src/bookmarkletify.js to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (/kill-sticky/src/bookmarkletify.js:1:18) {
  code: 'ERR_REQUIRE_ESM'
}
```

\[1]: https://github.com/sindresorhus/get-stdin/commit/8f70f58fd5cb9e5836d58e2f8dda16128c5e3f3e

\[2]: https://nodejs.org/docs/latest-v19.x/api/esm.html#no-node_path