### PR TITLE
Switch from ENTRYPOINT to CMD Dockerfile and clean up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,10 @@ FROM node:current-alpine
 
 WORKDIR /build/kill-sticky
 
-RUN set -x \
-	&& mkdir /build/node_modules \
+RUN mkdir /build/node_modules \
         && npm install -g uglify-js mustache \
         && npm install get-stdin
 
-ENTRYPOINT uglifyjs <src/kill-sticky.js \
+CMD uglifyjs <src/kill-sticky.js \
         | node src/bookmarkletify.mjs \
         | mustache - src/README.mustache.md > README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM node:current-alpine
 
-WORKDIR /kill-sticky
+WORKDIR /build/kill-sticky
 
 RUN set -x \
-        && npm install uglify-js get-stdin mustache -g
+	&& mkdir /build/node_modules \
+        && npm install -g uglify-js mustache \
+        && npm install get-stdin
 
 ENTRYPOINT uglifyjs <src/kill-sticky.js \
-        | NODE_PATH=$(npm root --quiet -g) node src/bookmarkletify.js \
+        | node src/bookmarkletify.mjs \
         | mustache - src/README.mustache.md > README.md

--- a/Makefile
+++ b/Makefile
@@ -2,5 +2,5 @@
 
 all:
 	docker build . -t kill-sticky
-	docker run --rm -t -v $(shell pwd):/kill-sticky kill-sticky
+	docker run --rm -t -v $(shell pwd):/build/kill-sticky kill-sticky
 	docker rmi kill-sticky

--- a/Makefile
+++ b/Makefile
@@ -2,5 +2,5 @@
 
 all:
 	docker build . -t kill-sticky
-	docker run --rm -t -v $(shell pwd):/build/kill-sticky kill-sticky
+	docker run --rm -t -v ${PWD}:/build/kill-sticky kill-sticky
 	docker rmi kill-sticky

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ We're creating a bookmarklet, so our code needs to be minified and URL encoded.
 Run the following the project root directory:
 
 ```console
-$ docker build . -t kill-sticky && docker run --rm -it -v $(pwd):/kill-sticky kill-sticky
+$ docker build . -t kill-sticky && docker run --rm -it -v $(pwd):/build/kill-sticky kill-sticky
 ```
 
 _This will update the project README.md with the build version._

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ We're creating a bookmarklet, so our code needs to be minified and URL encoded.
 Run the following the project root directory:
 
 ```console
-$ docker build . -t kill-sticky && docker run --rm -it -v $(pwd):/build/kill-sticky kill-sticky
+$ docker build . -t kill-sticky && docker run --rm -it -v $PWD:/build/kill-sticky kill-sticky
 ```
 
 _This will update the project README.md with the build version._

--- a/src/README.mustache.md
+++ b/src/README.mustache.md
@@ -72,7 +72,7 @@ We're creating a bookmarklet, so our code needs to be minified and URL encoded.
 Run the following the project root directory:
 
 ```console
-$ docker build . -t kill-sticky && docker run --rm -it -v $(pwd):/kill-sticky kill-sticky
+$ docker build . -t kill-sticky && docker run --rm -it -v $(pwd):/build/kill-sticky kill-sticky
 ```
 
 _This will update the project README.md with the build version._

--- a/src/README.mustache.md
+++ b/src/README.mustache.md
@@ -72,7 +72,7 @@ We're creating a bookmarklet, so our code needs to be minified and URL encoded.
 Run the following the project root directory:
 
 ```console
-$ docker build . -t kill-sticky && docker run --rm -it -v $(pwd):/build/kill-sticky kill-sticky
+$ docker build . -t kill-sticky && docker run --rm -it -v $PWD:/build/kill-sticky kill-sticky
 ```
 
 _This will update the project README.md with the build version._

--- a/src/bookmarkletify.mjs
+++ b/src/bookmarkletify.mjs
@@ -1,4 +1,4 @@
-const getStdin = require('get-stdin');
+import getStdin from 'get-stdin';
 
 getStdin().then(str => {
     console.log(`{"bookmarklet": "javascript:${encodeURIComponent(str)}"}`);


### PR DESCRIPTION
Merge after #7.

ENTRYPOINT and CMD are similar but CMD is more appropriate because it allows overriding on the command line, e.g. `docker run ... kill-sticky sh` can now be used to start an interactive shell for debugging.

Also remove `set -x` from Dockerfile (unnecessary because we use `&&`), and switch from `$(pwd)` to `$PWD` in the build commands because `$PWD` is cleaner (especially in the Makefile).
